### PR TITLE
(docs) Fix typos and run Terraform fmt

### DIFF
--- a/examples/cross-account-with-sidecar-module/main.tf
+++ b/examples/cross-account-with-sidecar-module/main.tf
@@ -1,29 +1,29 @@
 locals {
-    sidecar_dns_name = "sidecar.mycompany.com"
+  sidecar_dns_name = "sidecar.mycompany.com"
 }
 
 module "cyral_sidecar" {
-    providers = {
-        aws = aws.sidecar
-    }
+  providers = {
+    aws = aws.sidecar
+  }
 
-    source  = "cyralinc/sidecar-aws/cyral"
-    version = ">= 2.7.0"
+  source  = "cyralinc/sidecar-aws/cyral"
+  version = ">= 2.7.0"
 
-    sidecar_custom_certificate_account_id = "111111111111"
-    sidecar_dns_name = local.sidecar_dns_name
+  sidecar_custom_certificate_account_id = "111111111111"
+  sidecar_dns_name                      = local.sidecar_dns_name
 
-    ## Remaining of your code goes here...
+  ## Remaining of your code goes here...
 }
 
-module "cyral_sidecar_custom_certificate" {
-    providers = {
-        aws = aws.custom_certificate
-    }
-    source = "cyralinc/sidecar-custom-certificate-letsencrypt/aws"
-    version = ">= 1.0.0"
+module "cyral_sidecar_custom_certificate_letsencrypt" {
+  providers = {
+    aws = aws.custom_certificate
+  }
+  source  = "cyralinc/sidecar-custom-certificate-letsencrypt/aws"
+  version = ">= 1.0.0"
 
-    sidecar_domain = local.sidecar_dns_name
-    sidecar_custom_certificate_secret_arn = module.cyral_sidecar.sidecar_custom_certificate_secret_arn
-    sidecar_custom_certificate_role_arn = module.cyral_sidecar.sidecar_custom_certificate_role_arn
+  sidecar_domain                        = local.sidecar_dns_name
+  sidecar_custom_certificate_secret_arn = module.cyral_sidecar.sidecar_custom_certificate_secret_arn
+  sidecar_custom_certificate_role_arn   = module.cyral_sidecar.sidecar_custom_certificate_role_arn
 }

--- a/examples/cross-account-with-sidecar-module/provider.tf
+++ b/examples/cross-account-with-sidecar-module/provider.tf
@@ -6,6 +6,6 @@ provider "aws" {
 
 provider "aws" {
   alias   = "custom_certificate"
-  region = "us-east-1"
+  region  = "us-east-1"
   profile = "certificate_account"
 }

--- a/examples/cross-account/main.tf
+++ b/examples/cross-account/main.tf
@@ -1,8 +1,8 @@
-module "cyral_sidecar_custom_certificate" {
-  source = "cyralinc/sidecar-custom-certificate-letsencrypt/aws"
+module "cyral_sidecar_custom_certificate_letsencrypt" {
+  source  = "cyralinc/sidecar-custom-certificate-letsencrypt/aws"
   version = ">= 1.0.0"
 
-  sidecar_domain = "my-sidecar.my-domain.com"
+  sidecar_domain                        = "my-sidecar.my-domain.com"
   sidecar_custom_certificate_secret_arn = "arn:aws:secretsmanager:us-east-1:111111111111:secret:/cyral/sidecars/certificate/MySidecar-abcdef"
-  sidecar_custom_certificate_role_arn = "arn:aws:iam::222222222222:role/sm-role"
+  sidecar_custom_certificate_role_arn   = "arn:aws:iam::222222222222:role/sm-role"
 }

--- a/examples/custom-renewal/README.md
+++ b/examples/custom-renewal/README.md
@@ -4,5 +4,5 @@ If you want to customize how often the application checks and renews the
 sidecar certificate, use the variables `renewal_interval_checks` and
 `renewal_interval_window_start`.
 
-For the configuration provider here, the application will check the certificate 
+For the configuration provided here, the application will check the certificate
 every day and renew it if there are no more than 30 days left until it expires.

--- a/examples/custom-renewal/main.tf
+++ b/examples/custom-renewal/main.tf
@@ -1,8 +1,8 @@
-module "cyral_sidecar_custom_certificate" {
-  source = "cyralinc/sidecar-custom-certificate-letsencrypt/aws"
+module "cyral_sidecar_custom_certificate_letsencrypt" {
+  source  = "cyralinc/sidecar-custom-certificate-letsencrypt/aws"
   version = ">= 1.0.0"
 
-  sidecar_domain = "my-sidecar.my-domain.com"
-  renewal_interval_checks = 1
+  sidecar_domain                = "my-sidecar.my-domain.com"
+  renewal_interval_checks       = 1
   renewal_interval_window_start = 30
 }

--- a/examples/snowflake/main.tf
+++ b/examples/snowflake/main.tf
@@ -1,7 +1,7 @@
-module "cyral_sidecar_custom_certificate" {
-  source = "cyralinc/sidecar-custom-certificate-letsencrypt/aws"
+module "cyral_sidecar_custom_certificate_letsencrypt" {
+  source  = "cyralinc/sidecar-custom-certificate-letsencrypt/aws"
   version = ">= 1.0.0"
 
-  sidecar_domain = "my-sidecar.my-domain.com"
+  sidecar_domain           = "my-sidecar.my-domain.com"
   snowflake_account_region = "us-east-1"
 }

--- a/output.tf
+++ b/output.tf
@@ -1,8 +1,8 @@
 output "certificate_secret_arn" {
   description = "Secret containing the TLS certificate that will be used by the sidecar."
-  value       = local.create_certificate_secret ? (
-      aws_secretsmanager_secret.certificate_secret[0].arn
+  value = local.create_certificate_secret ? (
+    aws_secretsmanager_secret.certificate_secret[0].arn
     ) : (
-      var.sidecar_custom_certificate_secret_arn
+    var.sidecar_custom_certificate_secret_arn
   )
 }


### PR DESCRIPTION
## Description of the change

There was a typo that could confuse users in `examples/custom-renewal`. Also, the examples where not formatted according to `terraform fmt`. And in the examples, we were using the module `sidecar_custom_certificate` instead of `sidecar_custom_certificate_letsencrypt`, which could cause some confusion.

### Testing
`terraform validate` continues working. Nothing was changed that could affect functionality in the main module, not even names. Only `terraform fmt` was run on the main module, nothing else.

For the examples, '_letsencrypt' was added as a suffix to the module names, to keep consistency. `terraform fmt` was run for all the examples.
